### PR TITLE
Remove references to stravawindanalysis.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                   <div class="pfblock-subtitle">
                      Hello, my name is Horatiu Lazu, currently studying Computer Science at the University of Waterloo. I'm currently a Software Engineering Intern at <a href="https://about.google/" target="_blank">Google</a>. Formerly at <a href="https://about.fb.com/company-info" target="_blank">Facebook</a> in Seattle, <a href="https://www.citadelsecurities.com/" target="_blank">Citadel Securities</a> in Chicago, <a href="https://www.yelp.com/" target="_blank">Yelp</a>  in San Francisco, twice at <a href="https://www.bloomberg.com/professional/" target="_blank">Bloomberg LP</a> in New York</a>.
                      <br><br>
-                     Road cycling is my hobby, with my <a href="http://stravawindanalysis.com" target="_blank">Strava Wind Analysis</a> site providing analytics and data visualization to over 120,000 users.<br> Feel free to visit my <a href="./blog/index.html" target="_blank">Blog</a>, <a href="http://github.com/MathBunny" target="_blank">GitHub</a>, or my <a href="http://youtube.com/ComputerBunnyMath123" target="_blank">YouTube Channel</a> that has over 1.4 million views.
+                     Road cycling is my hobby, with my <a href="https://github.com/MathBunny/strava-wind-analysis" target="_blank">Strava Wind Analysis</a> site providing analytics and data visualization to over 120,000 users.<br> Feel free to visit my <a href="./blog/index.html" target="_blank">Blog</a>, <a href="http://github.com/MathBunny" target="_blank">GitHub</a>, or my <a href="http://youtube.com/ComputerBunnyMath123" target="_blank">YouTube Channel</a> that has over 1.4 million views.
                   </div>
                   <!-- <div class="pfblock-line"></div> -->
                </div>
@@ -510,13 +510,13 @@
          </div>
          <div class="row">
             <div class="col-xs-12 col-sm-6 col-md-6">
-               <a href="http://stravawindanalysis.com" target="_blank" style="text-decoration:none;color:white;" target="_blank" style="text-decoration:none;">
+               <a href="https://github.com/MathBunny/strava-wind-analysis" target="_blank" style="text-decoration:none;color:white;" target="_blank" style="text-decoration:none;">
                   <div class="grid wow zoomIn">
                      <figure class="effect-bubba">
                         <img src="assets/images/stravawindanalysis.png" alt="Horatiu Lazu"/><!-- b -->
                         <figcaption>
                            <h2>
-               <a href = "http://stravawindanalysis.com" target="_blank" style="text-decoration:none;color:white;"> Strava Wind <span>Analysis</span> </a></h2>
+               <a href = "https://github.com/MathBunny/strava-wind-analysis" target="_blank" style="text-decoration:none;color:white;"> Strava Wind <span>Analysis</span> </a></h2>
                <p>Provides historical and aggregate ride/segment analytics, data visualization and machine learning for cyclists on the Strava platform</p>
                </figcaption>
                </figure>


### PR DESCRIPTION
**Context**
First, I did not renew the domain so it is no longer a functional website. Even worse, the website is redirecting to an inappropriate destination.

**Test Plan**
- Verified new URLs redirect to intended source 